### PR TITLE
feat(mysql-db-init): Setup, MM-360

### DIFF
--- a/mysql-db-init/Dockerfile
+++ b/mysql-db-init/Dockerfile
@@ -1,0 +1,9 @@
+FROM mysql:8.0.33
+
+LABEL name=@strg-at/mysql-db-init
+LABEL maintainer=STRG.
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/mysql-db-init/README.md
+++ b/mysql-db-init/README.md
@@ -20,6 +20,7 @@ database (schema) initialization helper
 |                      | Description          |
 | :------------------- | :------------------- |
 | **MYSQL_HOST**       | MYSQL host           |
+| **MYSQL_SUPER_USER** | MYSQL admin user     |
 | **MYSQL_SUPER_PASS** | MYSQL admin password |
 | **MYSQL_USER**       | MYSQL user           |
 | **MYSQL_PASS**       | MYSQL password       |
@@ -49,7 +50,8 @@ run db-init container
 ```console
 docker run --rm -it --name mysql-db-init \
   -e MYSQL_HOST=<local-ip> \
-  -e MYSQL_SUPER_PASS=MYSQL \
+  -e MYSQL_SUPER_USER=root \
+  -e MYSQL_SUPER_PASS=mysql \
   -e MYSQL_USER=testing \
   -e MYSQL_PASS=testing \
   -e MYSQL_DB=testing \
@@ -59,26 +61,23 @@ docker run --rm -it --name mysql-db-init \
 connect to MYSQL instance
 
 ```console
-docker exec -it mysql mysql -h <local-ip> -uroot
+docker exec -it mysql mysql -h <local-ip> -uroot -pmysql
 ```
 
-list user and databases
+list user, databases and permissions
 
 ```console
-mysql> SELECT user FROM mysql.user;
+mysql> SELECT host,user,authentication_string FROM mysql.user;
 mysql> SHOW DATABASES;
+mysql> SHOW GRANTS FOR testing@"%";
 ```
-
-## Notice
-
-Modified version of onedr0ps [MYSQL-initdb][onedr0p-postgres-db-init] for MySQL (tested up to version 8.0).
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 
 <!-- Links -->
 
-[onedr0p-postgres-db-init]: https://github.com/onedr0p/containers/tree/main/apps/postgres-initdb
+<!-- TBD -->
 
 <!-- Badges -->
 

--- a/mysql-db-init/README.md
+++ b/mysql-db-init/README.md
@@ -71,14 +71,14 @@ mysql> SHOW DATABASES;
 
 ## Notice
 
-Modified version of onedr0ps [MYSQL-initdb][onedr0p-mysql-db-init] for MySQL (tested up to version 8.0).
+Modified version of onedr0ps [MYSQL-initdb][onedr0p-postgres-db-init] for MySQL (tested up to version 8.0).
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 
 <!-- Links -->
 
-[onedr0p-mysql-db-init]: https://github.com/onedr0p/containers/tree/main/apps/MYSQL-initdb
+[onedr0p-postgres-db-init]: https://github.com/onedr0p/containers/tree/main/apps/postgres-initdb
 
 <!-- Badges -->
 

--- a/mysql-db-init/README.md
+++ b/mysql-db-init/README.md
@@ -1,0 +1,85 @@
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD033 -->
+<!-- markdownlint-disable MD028 -->
+
+<!-- PROJECT SHIELDS -->
+<!--
+*** I'm using markdown "reference style" links for readability.
+*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
+*** See the bottom of this document for the declaration of the reference variables
+*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
+*** https://www.markdownguide.org/basic-syntax/#reference-style-links
+-->
+
+# mysql-db-init
+
+database (schema) initialization helper
+
+## ENV
+
+|                      | Description          |
+| :------------------- | :------------------- |
+| **MYSQL_HOST**       | MYSQL host           |
+| **MYSQL_SUPER_PASS** | MYSQL admin password |
+| **MYSQL_USER**       | MYSQL user           |
+| **MYSQL_PASS**       | MYSQL password       |
+| **MYSQL_DB**         | MYSQL database       |
+
+| (\*) required
+
+## How to test
+
+build docker container
+
+```console
+docker build -t mysql-db-init ./mysql-db-init
+```
+
+create local MYSQL instance
+
+```console
+docker run --rm --name mysql \
+  -e MYSQL_ROOT_PASSWORD=mysql \
+  --network=host \
+  mysql
+```
+
+run db-init container
+
+```console
+docker run --rm -it --name mysql-db-init \
+  -e MYSQL_HOST=<local-ip> \
+  -e MYSQL_SUPER_PASS=MYSQL \
+  -e MYSQL_USER=testing \
+  -e MYSQL_PASS=testing \
+  -e MYSQL_DB=testing \
+  mysql-db-init
+```
+
+connect to MYSQL instance
+
+```console
+docker exec -it mysql mysql -h <local-ip> -uroot
+```
+
+list user and databases
+
+```console
+mysql> SELECT user FROM mysql.user;
+mysql> SHOW DATABASES;
+```
+
+## Notice
+
+Modified version of onedr0ps [MYSQL-initdb][onedr0p-mysql-db-init] for MySQL (tested up to version 8.0).
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
+<!-- Links -->
+
+[onedr0p-mysql-db-init]: https://github.com/onedr0p/containers/tree/main/apps/MYSQL-initdb
+
+<!-- Badges -->
+
+<!-- TBD -->

--- a/mysql-db-init/entrypoint.sh
+++ b/mysql-db-init/entrypoint.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 export MYSQL_HOST="${MYSQL_HOST}"
-export MYSQL_ROOT_USER="${MYSQL_SUPER_USER}"
 export MYSQL_ROOT_PASSWORD="${MYSQL_SUPER_PASS}"
 
-if [[ -z "${MYSQL_HOST}" || -z "${MYSQL_ROOT_USER}"|| -z "${MYSQL_ROOT_PASSWORD}" || -z "${MYSQL_USER}" || -z "${MYSQL_PASS}" || -z "${MYSQL_DB}" ]]; then
+if [[ -z "${MYSQL_HOST}" || -z "${MYSQL_SUPER_USER}" || -z "${MYSQL_ROOT_PASSWORD}" || -z "${MYSQL_USER}" || -z "${MYSQL_PASS}" || -z "${MYSQL_DB}" ]]; then
   printf "\e[1;32m%-6s\e[m\n" "environment variables missing ..."
   exit 1
 fi

--- a/mysql-db-init/entrypoint.sh
+++ b/mysql-db-init/entrypoint.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+export MYSQLHOST="${MYSQL_HOST}"
+export MYSQLPASSWORD="${MYSQL_SUPER_PASS}"
+
+if [[ -z "${MYSQLHOST}" || -z "${MYSQLPASSWORD}" || -z "${MYSQL_USER}" || -z "${MYSQL_PASS}" || -z "${MYSQL_DB}" ]]; then
+  printf "\e[1;32m%-6s\e[m\n" "environment variables missing ..."
+  exit 1
+fi
+
+until mysqladmin --user=root --password=${MYSQLPASSWORD} --protocol tcp ping -h ${MYSQLHOST} 2>/dev/null
+do
+  printf "\e[1;32m%-6s\e[m\n" "waiting for host '${MYSQLHOST}' ..."
+  sleep 1
+done
+
+user_exists=$(\
+  mysql --user=root \
+        --password=${MYSQLPASSWORD} \
+        --protocol tcp -se "SELECT 1 FROM mysql.user WHERE user = '${MYSQL_USER}';" \
+        2>/dev/null | xargs
+)
+
+if [[ -z "${user_exists}" ]]; then
+  printf "\e[1;32m%-6s\e[m\n" "create database user ${MYSQL_USER} ..."
+  mysql --user=root \
+        --password=${MYSQLPASSWORD} \
+        --protocol tcp \
+        -e "CREATE USER ${MYSQL_USER}@'%' IDENTIFIED BY '${MYSQL_PASS}';" \
+        2>/dev/null
+else
+  printf "\e[1;32m%-6s\e[m\n" "database user exists, skipping creation ..."
+fi
+
+for init_db in ${MYSQL_DB}
+do
+  database_exists=$(\
+    mysql --user=root \
+          --password="${MYSQLPASSWORD}" \
+          --protocol tcp \
+          -e "SHOW DATABASES LIKE '${init_db}';" \
+          2>/dev/null
+  )
+
+  if [[ -z "${database_exists}" ]]; then
+    printf "\e[1;32m%-6s\e[m\n" "create database ${init_db} ..."
+    mysql --user=root \
+          --password=${MYSQLPASSWORD} \
+          --protocol tcp \
+          -e "CREATE DATABASE ${init_db};" \
+          2>/dev/null
+  else
+    printf "\e[1;32m%-6s\e[m\n" "database exists, skipping creation ..."
+  fi
+
+  printf "\e[1;32m%-6s\e[m\n" "update user privileges on database ..."
+  mysql --user=root \
+        --password=${MYSQLPASSWORD} \
+        --protocol tcp \
+        -e "GRANT ALL PRIVILEGES ON ${init_db}.* TO '${MYSQL_USER}'@'%';" \
+        2>/dev/null
+
+  mysql --user=root \
+        --password=${MYSQLPASSWORD} \
+        --protocol tcp \
+        -e "FLUSH PRIVILEGES;" \
+        2>/dev/null
+done

--- a/mysql-db-init/entrypoint.sh
+++ b/mysql-db-init/entrypoint.sh
@@ -10,6 +10,7 @@ fi
 
 until
   mysqladmin \
+    --host=${MYSQL_HOST} \
     --user=${MYSQL_SUPER_USER} \
     --password=${MYSQL_ROOT_PASSWORD} \
     --protocol tcp \
@@ -21,6 +22,7 @@ done
 
 user_exists=$(\
   mysql \
+    --host=${MYSQL_HOST} \
     --user=${MYSQL_SUPER_USER} \
     --password=${MYSQL_ROOT_PASSWORD} \
     --protocol tcp \
@@ -30,6 +32,7 @@ user_exists=$(\
 if [[ -z "${user_exists}" ]]; then
   printf "\e[1;32m%-6s\e[m\n" "create database user ${MYSQL_USER} ..."
   mysql \
+    --host=${MYSQL_HOST} \
     --user=${MYSQL_SUPER_USER} \
     --password=${MYSQL_ROOT_PASSWORD} \
     --protocol tcp \
@@ -40,6 +43,7 @@ fi
 
 printf "\e[1;32m%-6s\e[m\n" "update database user password ..."
 mysql \
+  --host=${MYSQL_HOST} \
   --user=${MYSQL_SUPER_USER} \
   --password=${MYSQL_ROOT_PASSWORD} \
   --protocol tcp \
@@ -49,6 +53,7 @@ for init_db in ${MYSQL_DB}
 do
   database_exists=$(\
     mysql \
+    --host=${MYSQL_HOST} \
     --user=${MYSQL_SUPER_USER} \
     --password=${MYSQL_ROOT_PASSWORD} \
     --protocol tcp \
@@ -58,6 +63,7 @@ do
   if [[ -z "${database_exists}" ]]; then
     printf "\e[1;32m%-6s\e[m\n" "create database ${init_db} ..."
     mysql \
+      --host=${MYSQL_HOST} \
       --user=${MYSQL_SUPER_USER} \
       --password=${MYSQL_ROOT_PASSWORD} \
       --protocol tcp \
@@ -68,6 +74,7 @@ do
 
   printf "\e[1;32m%-6s\e[m\n" "grant all privileges on ${init_db} to user ${MYSQL_USER} ..."
   mysql \
+    --host=${MYSQL_HOST} \
     --user=${MYSQL_SUPER_USER} \
     --password=${MYSQL_ROOT_PASSWORD} \
     --protocol tcp \
@@ -76,6 +83,7 @@ done
 
 printf "\e[1;32m%-6s\e[m\n" "flush privileges ..."
 mysql \
+  --host=${MYSQL_HOST} \
   --user=${MYSQL_SUPER_USER} \
   --password=${MYSQL_ROOT_PASSWORD} \
   --protocol tcp \


### PR DESCRIPTION
`docker run --rm --name mysql -e MYSQL_ROOT_PASSWORD=mysql  --network=host mysql`

... MySQL is starting up ...

`docker run --rm -it --network=host --name mysql-db-init -e MYSQL_HOST=localhost  -e MYSQL_SUPER_PASS=mysql -e MYSQL_USER=testing -e MYSQL_PASS=testing -e MYSQL_DB=testing mysql-db-init`

```
❯ docker run --rm -it --network=host --name mysql-db-init -e MYSQL_HOST=localhost  -e MYSQL_SUPER_PASS=mysql -e MYSQL_USER=testing -e MYSQL_PASS=testing -e MYSQL_DB=testing mysql-db-init
mysqld is alive
create database user testing ...
create database testing ...
update user privileges on database ...

❯ docker run --rm -it --network=host --name mysql-db-init -e MYSQL_HOST=localhost  -e MYSQL_SUPER_PASS=mysql -e MYSQL_USER=testing -e MYSQL_PASS=testing -e MYSQL_DB=testing mysql-db-init
mysqld is alive
database user exists, skipping creation ...
database exists, skipping creation ...
update user privileges on database ...
```

If the instance is not responding, this is what happens:

```
❯ docker run --rm -it --network=host --name mysql-db-init -e MYSQL_HOST=localhost  -e MYSQL_SUPER_PASS=mysql -e MYSQL_USER=testing -e MYSQL_PASS=testing -e MYSQL_DB=testing mysql-db-init
waiting for host 'localhost' ...
waiting for host 'localhost' ...
waiting for host 'localhost' ...
waiting for host 'localhost' ...
waiting for host 'localhost' ...
waiting for host 'localhost' ...
```

The moment it is answering, it displays `mysqld is alive` and continues. 

I had to use `--protocol tcp` because by default mysql uses a socket to connect to a database.
