### PR TITLE
feat(Dockerfile): Copy openvpn startup script and create a symlink in HOME, INPRO-2035

### DIFF
--- a/gcloud-workstation-phpstorm/Dockerfile
+++ b/gcloud-workstation-phpstorm/Dockerfile
@@ -16,6 +16,7 @@ RUN apt install -y \
   golang-go \
   go-task \
   htop \
+  openvpn \
   pre-commit \
   software-properties-common \
   sops \
@@ -36,5 +37,11 @@ RUN apt install -y \
 
 # git
 RUN add-apt-repository ppa:git-core/ppa -y && apt update && apt install -y git
+
+# Copy of the openvpn automatic startup script (owned by root, can't be deleted by mistake)
+COPY start-vpn.sh /etc/workstation-startup.d/999_start-vpn.sh
+
+# Create symlink to the openvpn startup script for manual usage
+RUN ln -s /etc/workstation-startup.d/999_start-vpn.sh /home/user/start-vpn.sh
 
 RUN apt-get clean

--- a/gcloud-workstation-phpstorm/Dockerfile
+++ b/gcloud-workstation-phpstorm/Dockerfile
@@ -38,10 +38,9 @@ RUN apt install -y \
 # git
 RUN add-apt-repository ppa:git-core/ppa -y && apt update && apt install -y git
 
-# Copy of the openvpn automatic startup script (owned by root, can't be deleted by mistake)
+# openvpn
 COPY start-vpn.sh /etc/workstation-startup.d/999_start-vpn.sh
-
-# Create symlink to the openvpn startup script for manual usage
+RUN chmod +x /etc/workstation-startup.d/999_start-vpn.sh
 RUN ln -s /etc/workstation-startup.d/999_start-vpn.sh /home/user/start-vpn.sh
 
 RUN apt-get clean

--- a/gcloud-workstation-phpstorm/start-vpn.sh
+++ b/gcloud-workstation-phpstorm/start-vpn.sh
@@ -1,0 +1,24 @@
+#/bin/bash
+OVPN_CONFIG_FILE=~/openvpn-client.ovpn
+# Killing any openvpn connections in case this script is used when openvpn processes are already running
+sudo killall openvpn 2>/dev/null
+
+# We check if the OpenVPN configuration file is present. If it is
+if test -f "$OVPN_CONFIG_FILE"; then
+    echo "OpenVPN configuration file has been found, attempting connection."
+    sudo openvpn ~/openvpn-client.ovpn > /tmp/openvpn.log 2>&1 &
+    # Giving time to openvpn to try and connect (the openvpn command does not exit upon successful connection)
+    sleep 5
+    # We check if the string "openvpn" is found in the existing connections and use this to consider if the connection was a success or not.
+    if sudo netstat -tulpen | grep openvpn >/dev/null ;
+    then
+      echo "Connected to the VPN."
+      exit 0
+    else
+      echo "Connection to the VPN has failed. Please check the contents of /tmp/openvpn.log for further information."
+      exit 1
+    fi
+else
+    echo "The OpenVPN configuration file is missing. Please make sure that it exists in the home directory of the "user" user as openvpn-client.ovpn."
+    exit 1
+fi

--- a/gcloud-workstation-phpstorm/start-vpn.sh
+++ b/gcloud-workstation-phpstorm/start-vpn.sh
@@ -1,14 +1,19 @@
 #/bin/bash
-OVPN_CONFIG_FILE=~/openvpn-client.ovpn
+# This script is run automatically by root in the container.
+# Added sudo in case it needs to be run by the unprivileged user.
+OVPN_CONFIG_FILE=/home/user/openvpn-client.ovpn
+
 # Killing any openvpn connections in case this script is used when openvpn processes are already running
 sudo killall openvpn 2>/dev/null
 
 # We check if the OpenVPN configuration file is present. If it is
 if test -f "$OVPN_CONFIG_FILE"; then
     echo "OpenVPN configuration file has been found, attempting connection."
-    sudo openvpn ~/openvpn-client.ovpn > /tmp/openvpn.log 2>&1 &
+    sudo openvpn /home/user/openvpn-client.ovpn > /tmp/openvpn.log 2>&1 &
+
     # Giving time to openvpn to try and connect (the openvpn command does not exit upon successful connection)
     sleep 5
+
     # We check if the string "openvpn" is found in the existing connections and use this to consider if the connection was a success or not.
     if sudo netstat -tulpen | grep openvpn >/dev/null ;
     then

--- a/gcloud-workstation-phpstorm/start-vpn.sh
+++ b/gcloud-workstation-phpstorm/start-vpn.sh
@@ -24,6 +24,6 @@ if test -f "$OVPN_CONFIG_FILE"; then
       exit 1
     fi
 else
-    echo "The OpenVPN configuration file is missing. Please make sure that it exists in the home directory of the "user" user as openvpn-client.ovpn."
+    echo "The OpenVPN configuration file is missing. Please make sure that it exists in the home directory of the \"user\" user as openvpn-client.ovpn."
     exit 1
 fi

--- a/gcloud-workstation-vscode/Dockerfile
+++ b/gcloud-workstation-vscode/Dockerfile
@@ -16,6 +16,7 @@ RUN apt install -y \
   golang-go \
   go-task \
   htop \
+  openvpn \
   pre-commit \
   software-properties-common \
   sops \
@@ -36,6 +37,12 @@ RUN apt install -y \
 
 # git
 RUN add-apt-repository ppa:git-core/ppa -y && apt update && apt install -y git
+
+# Copy of the openvpn automatic startup script (owned by root, can't be deleted by mistake)
+COPY start-vpn.sh /etc/workstation-startup.d/999_start-vpn.sh
+
+# Create symlink to the openvpn startup script for manual usage
+RUN ln -s /etc/workstation-startup.d/999_start-vpn.sh /home/user/start-vpn.sh
 
 RUN apt-get clean
 

--- a/gcloud-workstation-vscode/Dockerfile
+++ b/gcloud-workstation-vscode/Dockerfile
@@ -38,10 +38,9 @@ RUN apt install -y \
 # git
 RUN add-apt-repository ppa:git-core/ppa -y && apt update && apt install -y git
 
-# Copy of the openvpn automatic startup script (owned by root, can't be deleted by mistake)
+# openvpn
 COPY start-vpn.sh /etc/workstation-startup.d/999_start-vpn.sh
-
-# Create symlink to the openvpn startup script for manual usage
+RUN chmod +x /etc/workstation-startup.d/999_start-vpn.sh
 RUN ln -s /etc/workstation-startup.d/999_start-vpn.sh /home/user/start-vpn.sh
 
 RUN apt-get clean

--- a/gcloud-workstation-vscode/start-vpn.sh
+++ b/gcloud-workstation-vscode/start-vpn.sh
@@ -1,0 +1,24 @@
+#/bin/bash
+OVPN_CONFIG_FILE=~/openvpn-client.ovpn
+# Killing any openvpn connections in case this script is used when openvpn processes are already running
+sudo killall openvpn 2>/dev/null
+
+# We check if the OpenVPN configuration file is present. If it is
+if test -f "$OVPN_CONFIG_FILE"; then
+    echo "OpenVPN configuration file has been found, attempting connection."
+    sudo openvpn ~/openvpn-client.ovpn > /tmp/openvpn.log 2>&1 &
+    # Giving time to openvpn to try and connect (the openvpn command does not exit upon successful connection)
+    sleep 5
+    # We check if the string "openvpn" is found in the existing connections and use this to consider if the connection was a success or not.
+    if sudo netstat -tulpen | grep openvpn >/dev/null ;
+    then
+      echo "Connected to the VPN."
+      exit 0
+    else
+      echo "Connection to the VPN has failed. Please check the contents of /tmp/openvpn.log for further information."
+      exit 1
+    fi
+else
+    echo "The OpenVPN configuration file is missing. Please make sure that it exists in the home directory of the "user" user as openvpn-client.ovpn."
+    exit 1
+fi

--- a/gcloud-workstation-vscode/start-vpn.sh
+++ b/gcloud-workstation-vscode/start-vpn.sh
@@ -1,14 +1,19 @@
 #/bin/bash
-OVPN_CONFIG_FILE=~/openvpn-client.ovpn
+# This script is run automatically by root in the container.
+# Added sudo in case it needs to be run by the unprivileged user.
+OVPN_CONFIG_FILE=/home/user/openvpn-client.ovpn
+
 # Killing any openvpn connections in case this script is used when openvpn processes are already running
 sudo killall openvpn 2>/dev/null
 
 # We check if the OpenVPN configuration file is present. If it is
 if test -f "$OVPN_CONFIG_FILE"; then
     echo "OpenVPN configuration file has been found, attempting connection."
-    sudo openvpn ~/openvpn-client.ovpn > /tmp/openvpn.log 2>&1 &
+    sudo openvpn /home/user/openvpn-client.ovpn > /tmp/openvpn.log 2>&1 &
+
     # Giving time to openvpn to try and connect (the openvpn command does not exit upon successful connection)
     sleep 5
+
     # We check if the string "openvpn" is found in the existing connections and use this to consider if the connection was a success or not.
     if sudo netstat -tulpen | grep openvpn >/dev/null ;
     then

--- a/gcloud-workstation-vscode/start-vpn.sh
+++ b/gcloud-workstation-vscode/start-vpn.sh
@@ -24,6 +24,6 @@ if test -f "$OVPN_CONFIG_FILE"; then
       exit 1
     fi
 else
-    echo "The OpenVPN configuration file is missing. Please make sure that it exists in the home directory of the "user" user as openvpn-client.ovpn."
+    echo "The OpenVPN configuration file is missing. Please make sure that it exists in the home directory of the \"user\" user as openvpn-client.ovpn."
     exit 1
 fi


### PR DESCRIPTION
- Adds a new bash script that aims at automatically starting up the openvpn vpn, based on the presence of $HOME/openvpn-client.ovpn
  - Script fails if the file doesn't exist
  - Script fails if the connection fails (and logs the errors in /tmp/openvpn.log)
- Creates a symlink in $HOME so that devs can manually trigger the connection if needed (original file is owned by root so can't be deleted).

Ideally, we would have made use of openvpn's systemd service for clients but since everything runs in a container, systemd is not usable.