### PR TITLE
Feature/inpro 2284 cloud workstation fixes

### DIFF
--- a/gcloud-workstation-phpstorm/Dockerfile
+++ b/gcloud-workstation-phpstorm/Dockerfile
@@ -1,5 +1,5 @@
 # https://console.cloud.google.com/artifacts/docker/cloud-workstations-images/us-central1/predefined/phpstorm
-FROM europe-west3-docker.pkg.dev/cloud-workstations-images/predefined/phpstorm:latest@sha256:797ac65531c3af0622c7cb40fb28783c5af7d89c9a0b25fa08cffee5d0b53c4d as base
+FROM europe-west3-docker.pkg.dev/cloud-workstations-images/predefined/phpstorm:latest@sha256:797ac65531c3af0622c7cb40fb28783c5af7d89c9a0b25fa08cffee5d0b53c4d AS base
 
 FROM ubuntu:22.04@sha256:340d9b015b194dc6e2a13938944e0d016e57b9679963fdeb9ce021daac430221
 
@@ -40,15 +40,19 @@ RUN apt update && apt install -y \
   containerd.io \
   docker-buildx-plugin \
   docker-compose-plugin \
+  gettext-base \
   golang-go \
   google-cloud-cli \
   go-task \
   htop \
+  make \
   openvpn \
   openssh-client \
   openssh-server \
   openssh-sftp-server \
   pre-commit \
+  ruby \
+  ruby-dev \
   software-properties-common \
   sops \
   vim \

--- a/gcloud-workstation-phpstorm/scripts/011_install-mdless.sh
+++ b/gcloud-workstation-phpstorm/scripts/011_install-mdless.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo -u user "gem install --user-install mdless" || true

--- a/gcloud-workstation-phpstorm/scripts/011_set-default-shell.sh
+++ b/gcloud-workstation-phpstorm/scripts/011_set-default-shell.sh
@@ -52,47 +52,7 @@ EOF
 fi
 
 if [ ! -f /home/user/.zshrc ]; then
-    cat <<'EOF' >/home/user/.zshrc
-# Set up the prompt
-
-autoload -Uz promptinit
-promptinit
-prompt adam1
-
-setopt histignorealldups sharehistory
-
-# Use emacs keybindings even if our EDITOR is set to vi
-bindkey -e
-
-# Keep 1000 lines of history within the shell and save it to ~/.zsh_history:
-HISTSIZE=1000
-SAVEHIST=1000
-HISTFILE=~/.zsh_history
-
-# Use modern completion system
-autoload -Uz compinit
-compinit
-
-zstyle ':completion:*' auto-description 'specify: %d'
-zstyle ':completion:*' completer _expand _complete _correct _approximate
-zstyle ':completion:*' format 'Completing %d'
-zstyle ':completion:*' group-name ''
-zstyle ':completion:*' menu select=2
-eval "$(dircolors -b)"
-zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
-zstyle ':completion:*' list-colors ''
-zstyle ':completion:*' list-prompt %SAt %p: Hit TAB for more, or the character to insert%s
-zstyle ':completion:*' matcher-list '' 'm:{a-z}={A-Z}' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=* l:|=*'
-zstyle ':completion:*' menu select=long
-zstyle ':completion:*' select-prompt %SScrolling active: current selection at %p%s
-zstyle ':completion:*' use-compctl false
-zstyle ':completion:*' verbose true
-
-zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
-zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
-
-alias docker-compose='docker compose'
-EOF
+    cp /root/.zshrc /home/user/.zshrc
     echo "path+=('/home/user/.local/share/gem/ruby/$RUBY_VER/bin')" >> /home/user/.zshrc
 fi
 

--- a/gcloud-workstation-phpstorm/scripts/011_set-default-shell.sh
+++ b/gcloud-workstation-phpstorm/scripts/011_set-default-shell.sh
@@ -4,7 +4,12 @@
 chsh -s $(which zsh) root || true
 chsh -s $(which zsh) user || true
 
-cat <<'EOF' >/home/user/.zshrc
+# Hack to get the latest ruby version installed
+RUBY_VER=$(ls -alt /home/user/.local/share/gem/ruby | sed -n '2p' | cut -d ' ' -f9)
+
+# Only set the default zshrc configuration if the file doesn't exist
+if [ ! -f /root/.zshrc ]; then
+    cat <<'EOF' >/root/.zshrc
 # Set up the prompt
 
 autoload -Uz promptinit
@@ -42,9 +47,12 @@ zstyle ':completion:*' verbose true
 
 zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
 zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
+alias docker-compose='docker compose'
 EOF
+fi
 
-cat <<'EOF' >/root/.zshrc
+if [ ! -f /home/user/.zshrc ]; then
+    cat <<'EOF' >/home/user/.zshrc
 # Set up the prompt
 
 autoload -Uz promptinit
@@ -82,4 +90,10 @@ zstyle ':completion:*' verbose true
 
 zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
 zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
+
+alias docker-compose='docker compose'
 EOF
+    echo "path+=('/home/user/.local/share/gem/ruby/$RUBY_VER/bin')" >> /home/user/.zshrc
+fi
+
+chown user:user /home/user/.zshrc

--- a/gcloud-workstation-phpstorm/scripts/997_set-max-map-count.sh
+++ b/gcloud-workstation-phpstorm/scripts/997_set-max-map-count.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sysctl -w vm.max_map_count=262144

--- a/gcloud-workstation-phpstorm/scripts/999_start-vpn.sh
+++ b/gcloud-workstation-phpstorm/scripts/999_start-vpn.sh
@@ -8,7 +8,7 @@ OVPN_CONFIG_FILE=/home/user/openvpn-client.ovpn
 sudo pkill -9 openvpn 2>/dev/null
 
 # Cleaning up any existing log file before attempting a new connection
-sudo rm /tmp/openvpn.log || true
+sudo rm -f /tmp/openvpn.log || true
 
 # We check if the OpenVPN configuration file is present. If it is
 if test -f "$OVPN_CONFIG_FILE"; then
@@ -23,4 +23,6 @@ if test -f "$OVPN_CONFIG_FILE"; then
         printf "Connection to the VPN has failed. Please check the contents of /tmp/openvpn.log for further information.\n\r"
         exit 1
     fi
+else
+    echo "The OpenVPN configuration file has not been found, please create it in /home/user/openvpn-client.ovpn!"
 fi

--- a/gcloud-workstation-vscode/Dockerfile
+++ b/gcloud-workstation-vscode/Dockerfile
@@ -95,10 +95,11 @@ RUN apt-get clean
 RUN ln -s /usr/bin/go-task /usr/bin/task
 
 # set Code OSS port to 81
-# "The port 81 is not allowed by your configuration. Allowed ports are: [22, 80, 1024-65535]"
-# if portforwarding to 81: ERROR: The workstation does not have a server running on port 81
-RUN sed -i 's/80/81/' /etc/workstation-startup.d/110_start-code-oss.sh
+# not yet supported in terraform
+# https://cloud.google.com/sdk/docs/release-notes#cloud_workstations_2
+#RUN sed -i 's/80/81/' /etc/workstation-startup.d/110_start-code-oss.sh
+#EXPOSE 81
 
-EXPOSE 81
+EXPOSE 80
 
 ENTRYPOINT [ "/google/scripts/entrypoint.sh" ]

--- a/gcloud-workstation-vscode/Dockerfile
+++ b/gcloud-workstation-vscode/Dockerfile
@@ -1,5 +1,5 @@
 # https://console.cloud.google.com/artifacts/docker/cloud-workstations-images/us-central1/predefined/code-oss
-FROM europe-west3-docker.pkg.dev/cloud-workstations-images/predefined/code-oss:latest@sha256:64a761bd763a604b0885ffcc07e5e59bc231d5a3aa816f70240d4b8500fc4f92 as base
+FROM europe-west3-docker.pkg.dev/cloud-workstations-images/predefined/code-oss:latest@sha256:64a761bd763a604b0885ffcc07e5e59bc231d5a3aa816f70240d4b8500fc4f92 AS base
 
 FROM ubuntu:22.04@sha256:340d9b015b194dc6e2a13938944e0d016e57b9679963fdeb9ce021daac430221
 
@@ -41,16 +41,20 @@ RUN apt update && apt install -y \
   containerd.io \
   docker-buildx-plugin \
   docker-compose-plugin \
+  gettext-base \
   golang-go \
   google-cloud-cli \
   go-task \
   gpg \
   htop \
+  make \
   openvpn \
   openssh-client \
   openssh-server \
   openssh-sftp-server \
   pre-commit \
+  ruby \
+  ruby-dev \
   software-properties-common \
   sops \
   vim \
@@ -90,6 +94,11 @@ RUN apt-get clean
 # symlink for task binary
 RUN ln -s /usr/bin/go-task /usr/bin/task
 
-EXPOSE 80
+# set Code OSS port to 81
+# "The port 81 is not allowed by your configuration. Allowed ports are: [22, 80, 1024-65535]"
+# if portforwarding to 81: ERROR: The workstation does not have a server running on port 81
+RUN sed -i 's/80/81/' /etc/workstation-startup.d/110_start-code-oss.sh
+
+EXPOSE 81
 
 ENTRYPOINT [ "/google/scripts/entrypoint.sh" ]

--- a/gcloud-workstation-vscode/scripts/011_install-mdless.sh
+++ b/gcloud-workstation-vscode/scripts/011_install-mdless.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo -u user "gem install --user-install mdless" || true

--- a/gcloud-workstation-vscode/scripts/011_set-default-shell.sh
+++ b/gcloud-workstation-vscode/scripts/011_set-default-shell.sh
@@ -52,47 +52,7 @@ EOF
 fi
 
 if [ ! -f /home/user/.zshrc ]; then
-    cat <<'EOF' >/home/user/.zshrc
-# Set up the prompt
-
-autoload -Uz promptinit
-promptinit
-prompt adam1
-
-setopt histignorealldups sharehistory
-
-# Use emacs keybindings even if our EDITOR is set to vi
-bindkey -e
-
-# Keep 1000 lines of history within the shell and save it to ~/.zsh_history:
-HISTSIZE=1000
-SAVEHIST=1000
-HISTFILE=~/.zsh_history
-
-# Use modern completion system
-autoload -Uz compinit
-compinit
-
-zstyle ':completion:*' auto-description 'specify: %d'
-zstyle ':completion:*' completer _expand _complete _correct _approximate
-zstyle ':completion:*' format 'Completing %d'
-zstyle ':completion:*' group-name ''
-zstyle ':completion:*' menu select=2
-eval "$(dircolors -b)"
-zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
-zstyle ':completion:*' list-colors ''
-zstyle ':completion:*' list-prompt %SAt %p: Hit TAB for more, or the character to insert%s
-zstyle ':completion:*' matcher-list '' 'm:{a-z}={A-Z}' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=* l:|=*'
-zstyle ':completion:*' menu select=long
-zstyle ':completion:*' select-prompt %SScrolling active: current selection at %p%s
-zstyle ':completion:*' use-compctl false
-zstyle ':completion:*' verbose true
-
-zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
-zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
-
-alias docker-compose='docker compose'
-EOF
+    cp /root/.zshrc /home/user/.zshrc
     echo "path+=('/home/user/.local/share/gem/ruby/$RUBY_VER/bin')" >> /home/user/.zshrc
 fi
 

--- a/gcloud-workstation-vscode/scripts/011_set-default-shell.sh
+++ b/gcloud-workstation-vscode/scripts/011_set-default-shell.sh
@@ -4,7 +4,12 @@
 chsh -s $(which zsh) root || true
 chsh -s $(which zsh) user || true
 
-cat <<'EOF' >/home/user/.zshrc
+# Hack to get the latest ruby version installed
+RUBY_VER=$(ls -alt /home/user/.local/share/gem/ruby | sed -n '2p' | cut -d ' ' -f9)
+
+# Only set the default zshrc configuration if the file doesn't exist
+if [ ! -f /root/.zshrc ]; then
+    cat <<'EOF' >/root/.zshrc
 # Set up the prompt
 
 autoload -Uz promptinit
@@ -42,9 +47,12 @@ zstyle ':completion:*' verbose true
 
 zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
 zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
+alias docker-compose='docker compose'
 EOF
+fi
 
-cat <<'EOF' >/root/.zshrc
+if [ ! -f /home/user/.zshrc ]; then
+    cat <<'EOF' >/home/user/.zshrc
 # Set up the prompt
 
 autoload -Uz promptinit
@@ -82,4 +90,10 @@ zstyle ':completion:*' verbose true
 
 zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
 zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
+
+alias docker-compose='docker compose'
 EOF
+    echo "path+=('/home/user/.local/share/gem/ruby/$RUBY_VER/bin')" >> /home/user/.zshrc
+fi
+
+chown user:user /home/user/.zshrc

--- a/gcloud-workstation-vscode/scripts/997_set-max-map-count.sh
+++ b/gcloud-workstation-vscode/scripts/997_set-max-map-count.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sysctl -w vm.max_map_count=262144

--- a/gcloud-workstation-vscode/scripts/999_start-vpn.sh
+++ b/gcloud-workstation-vscode/scripts/999_start-vpn.sh
@@ -8,7 +8,7 @@ OVPN_CONFIG_FILE=/home/user/openvpn-client.ovpn
 sudo pkill -9 openvpn 2>/dev/null
 
 # Cleaning up any existing log file before attempting a new connection
-sudo rm /tmp/openvpn.log || true
+sudo rm -f /tmp/openvpn.log || true
 
 # We check if the OpenVPN configuration file is present. If it is
 if test -f "$OVPN_CONFIG_FILE"; then
@@ -23,4 +23,6 @@ if test -f "$OVPN_CONFIG_FILE"; then
         printf "Connection to the VPN has failed. Please check the contents of /tmp/openvpn.log for further information.\n\r"
         exit 1
     fi
+else
+    echo "The OpenVPN configuration file has not been found, please create it in /home/user/openvpn-client.ovpn!"
 fi


### PR DESCRIPTION
Fixes:
- `start-vpn` script:
  - use `-f` when deleting the openvpn log
- `~/.zshrc` is no longer overwritten on every start. There is now a check to see whether the file exists already or not. If it doesn't, it gets created; if it does, it doesn't get created.

Improvements:
- `start-vpn` script:
  - add message if openvpn conf file is missing
- Packages installed:
  - `mdless` via `gem` (hence the need for `ruby`, `ruby-dev` and `make`): couldn't get `snap` to work in the workstation
  - `gettext-base`
- alias for `docker-compose` created
- `vm.max_map_count=262144` is now set on startup