### PR TITLE
feat(gcloud-workstation-vscode): Set Code OSS port to 8084, INPRO-2293

### DIFF
--- a/gcloud-workstation-vscode/Dockerfile
+++ b/gcloud-workstation-vscode/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=base /usr/bin/workstation-startup /usr/bin/workstation-startup
 
 # installing pre-requirements
 RUN apt update && apt install -y \
-    ca-certificates gpg sudo curl
+  ca-certificates gpg sudo curl
 
 # preparing gsutil installation
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
@@ -95,11 +95,8 @@ RUN apt-get clean
 RUN ln -s /usr/bin/go-task /usr/bin/task
 
 # set Code OSS port to 81
-# not yet supported in terraform
-# https://cloud.google.com/sdk/docs/release-notes#cloud_workstations_2
-#RUN sed -i 's/80/81/' /etc/workstation-startup.d/110_start-code-oss.sh
-#EXPOSE 81
+RUN sed -i 's/80/8084/' /etc/workstation-startup.d/110_start-code-oss.sh
 
-EXPOSE 80
+EXPOSE 8084
 
 ENTRYPOINT [ "/google/scripts/entrypoint.sh" ]


### PR DESCRIPTION
Some devenvs use port 80 which would be used for Code OSS in Cloud Workstation. Because Code OSS is not expected to be used a lot, we move it to another arbitrary port: 8084 (only 80, 22 and 1024-65535 are allowed).