### PR TITLE
Feature/inpro 1744 create custom jenkins image

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -8,4 +8,5 @@ RUN apt update && apt install rsync wget -y
 RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
     chmod 700 get-helm-3 &&\
     ./get-helm-3
+
 USER jenkins

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.io/jenkins/jenkins:2.462.2-jdk17 AS jenkins
+USER root
+
+# install base packages
+RUN apt update && apt install rsync wget -y
+
+# install helm 3
+RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
+    chmod 700 get-helm-3 &&\
+    ./get-helm-3
+USER jenkins


### PR DESCRIPTION
From what I've seen we're at least using helm & rsync in jenkins at the moment so we need to have them in the jenkins image. This also means that we would need to have the image have the same version to be able to more easily integrate into the chart: `ghcr.io/strg-at/containers/jenkins:2.462.2-jdk17` otherwise we lose the version.