### PR TITLE
Feature/inpro 1744 create custom jenkins image

### DIFF
--- a/gcloud-workstation-vscode/README.md
+++ b/gcloud-workstation-vscode/README.md
@@ -36,12 +36,12 @@ docker buildx build -t gcloud-workstation-vscode ./gcloud-workstation-vscode
 run container
 
 ```console
-docker run --rm -it -p 2022:22 -p 8080:80 --privileged --name gcloud-workstation-vscode gcloud-workstation-vscode
+docker run --rm -it -p 2022:22 -p 8084:80 --privileged --name gcloud-workstation-vscode gcloud-workstation-vscode
 ```
 
 access IDE
 
-vscode is accessible via [localhost:8080](http://localhost:8080).
+vscode is accessible via [localhost:8084](http://localhost:8084).
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,12 +1,19 @@
-FROM docker.io/jenkins/jenkins:2.462.2-jdk17 AS jenkins
+FROM docker.io/jenkins/jenkins:2.462.2-jdk17
 USER root
 
+# prepare installation of gcloud sdk
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+
 # install base packages
-RUN apt update && apt install rsync wget -y
+RUN apt update && apt install rsync wget google-cloud-cli -y
+
+# install kubectl
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 # install helm 3
 RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
-    chmod 700 get-helm-3 &&\
-    ./get-helm-3
+    chmod 700 get-helm-3 && ./get-helm-3
 
 USER jenkins

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -8,4 +8,5 @@ RUN apt update && apt install rsync wget -y
 RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
     chmod 700 get-helm-3 &&\
     ./get-helm-3
+
 USER jenkins

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.io/jenkins/jenkins:2.462.2-jdk17 AS jenkins
+USER root
+
+# install base packages
+RUN apt update && apt install rsync wget -y
+
+# install helm 3
+RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
+    chmod 700 get-helm-3 &&\
+    ./get-helm-3
+USER jenkins

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,30 @@
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD033 -->
+<!-- markdownlint-disable MD028 -->
+
+<!-- PROJECT SHIELDS -->
+<!--
+*** I'm using markdown "reference style" links for readability.
+*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
+*** See the bottom of this document for the declaration of the reference variables
+*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
+*** https://www.markdownguide.org/basic-syntax/#reference-style-links
+-->
+
+# Jenkins
+
+This custom image is built on top of the official one and adds:
+
+- rsync
+- gcloud sdk
+- helm 3
+- kubectl
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
+<!-- Links -->
+
+<!-- Badges -->
+
+<!-- TBD -->


### PR DESCRIPTION
- Fixes README for cloud workstation vscode image since the port had been changed to 8084 some time ago already without being reflected there.
- Creates new custom Jenkins image with rsync, gcloud sdk, helm 3 and kubectl (builds fine locally)

I'll create a ticket for handling renovate just like this is done for ARC at the moment.