### PR TITLE
feat(approve-merge-pr): add app INPRO-2610

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Thumbs.db
 # Env files
 *.envrc
 *.env
+
+# Dependency directories
+node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 ---
 fail_fast: false
 default_stages:
-  - commit
-  - push
+  - pre-commit
+  - pre-push
 
 repos:
   - repo: https://github.com/thlorenz/doctoc

--- a/approve-merge-pr/Dockerfile
+++ b/approve-merge-pr/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22.13.0-alpine@sha256:f2dc6eea95f787e25f173ba9904c9d0647ab2506178c7b5b7c5a3d02bc4af145
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+USER node

--- a/approve-merge-pr/README.md
+++ b/approve-merge-pr/README.md
@@ -1,0 +1,79 @@
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD033 -->
+<!-- markdownlint-disable MD028 -->
+
+<!-- PROJECT SHIELDS -->
+<!--
+*** I'm using markdown "reference style" links for readability.
+*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
+*** See the bottom of this document for the declaration of the reference variables
+*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
+*** https://www.markdownguide.org/basic-syntax/#reference-style-links
+-->
+
+# github pr approval and merge tool
+
+automated tool for approving and merging github pull requests using github rest api.
+
+## ENV
+
+|                  | Description    |
+| :--------------- | :------------- |
+| **GITHUB_TOKEN** | PAT for GitHub |
+
+## Arguments
+
+```json
+{
+  "OWNER": "github repository owner/organization",
+  "REPO": "repository name",
+  "BRANCH": "branch to be merged",
+  "BASE": "target branch for merge"
+}
+```
+
+## How to test
+
+build docker container
+
+```shell
+docker build -t approve-merge-pr ./approve-merge-pr
+```
+
+run with required arguments
+
+```shell
+docker run --rm --name approve-merge-pr \
+  --env GITHUB_TOKEN="your_token" \
+  approve-merge-pr \
+  node index.js \
+  '{
+    "OWNER": "owner",
+    "REPO": "repo",
+    "BRANCH": "feature-branch",
+    "BASE": "main"
+  }'
+```
+
+or run the script with the required arguments:
+
+```shell
+node index.js \
+  '{
+    "OWNER": "owner",
+    "REPO": "repo",
+    "BRANCH": "feature-branch",
+    "BASE": "main"
+  }'
+```
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
+<!-- Links -->
+
+<!-- TBD -->
+
+<!-- Badges -->
+
+<!-- TBD -->

--- a/approve-merge-pr/index.js
+++ b/approve-merge-pr/index.js
@@ -1,0 +1,65 @@
+import { Octokit } from "@octokit/core"
+
+const args = JSON.parse(process.argv.slice(2)[0])
+
+const headers = {
+  "X-GitHub-Api-Version": "2022-11-28",
+  Accept: "application/vnd.github+json",
+}
+
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+})
+
+try {
+  const response = await octokit.request(
+    "GET /repos/{owner}/{repo}/pulls{?state,head,base,sort,direction,per_page,page}",
+    {
+      owner: `${args.OWNER}`,
+      repo: `${args.REPO}`,
+      state: "open",
+      head: `${args.OWNER}:${args.BRANCH}`,
+      base: `${args.BASE}`,
+      headers,
+    }
+  )
+
+  if (response.data.length === 0) {
+    console.log(JSON.stringify({ message: "success" }))
+    process.exit(0)
+  }
+
+  const review = await octokit.request(
+    "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+    {
+      owner: `${args.OWNER}`,
+      repo: `${args.REPO}`,
+      pull_number: response.data[0].number,
+      headers,
+    }
+  )
+
+  await octokit.request(
+    "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events",
+    {
+      owner: `${args.OWNER}`,
+      repo: `${args.REPO}`,
+      pull_number: response.data[0].number,
+      review_id: review.data.id,
+      body: "auto-approved by terraform release helper",
+      event: "APPROVE",
+      headers,
+    }
+  )
+
+  await octokit.request("PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge", {
+    owner: `${args.OWNER}`,
+    repo: `${args.REPO}`,
+    pull_number: response.data[0].number,
+    headers,
+  })
+  console.log(JSON.stringify({ message: "success" }))
+} catch (error) {
+  console.error(error)
+  process.exit(1)
+}

--- a/approve-merge-pr/package-lock.json
+++ b/approve-merge-pr/package-lock.json
@@ -1,0 +1,128 @@
+{
+  "name": "approve-merge-pr",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "approve-merge-pr",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "6.1.3"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
+      "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.3.tgz",
+      "integrity": "sha512-z+j7DixNnfpdToYsOutStDgeRzJSMnbj8T1C/oQjB6Aa+kRfNjs/Fn7W6c8bmlt6mfy3FkgeKBRnDjxQow5dow==",
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.1.2",
+        "@octokit/request": "^9.1.4",
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.2.tgz",
+      "integrity": "sha512-XybpFv9Ms4hX5OCHMZqyODYqGTZ3H6K6Vva+M9LR7ib/xr1y1ZnlChYv9H680y77Vd/i/k+thXApeRASBQkzhA==",
+      "dependencies": {
+        "@octokit/types": "^13.6.2",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.2.tgz",
+      "integrity": "sha512-bdlj/CJVjpaz06NBpfHhp4kGJaRZfz7AzC+6EwUImRtrwIw8dIgJ63Xg0OzV9pRn3rIzrt5c2sa++BL0JJ8GLw==",
+      "dependencies": {
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g=="
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.4.tgz",
+      "integrity": "sha512-tMbOwGm6wDII6vygP3wUVqFTw3Aoo0FnVQyhihh8vVq12uO3P+vQZeo2CKMpWtPSogpACD0yyZAlVlQnjW71DA==",
+      "dependencies": {
+        "@octokit/endpoint": "^10.0.0",
+        "@octokit/request-error": "^6.0.1",
+        "@octokit/types": "^13.6.2",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.6.tgz",
+      "integrity": "sha512-pqnVKYo/at0NuOjinrgcQYpEbv4snvP3bKMRqHaD9kIsk9u1LCpb2smHZi8/qJfgeNqLo5hNW4Z7FezNdEo0xg==",
+      "dependencies": {
+        "@octokit/types": "^13.6.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.7.0.tgz",
+      "integrity": "sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="
+    }
+  }
+}

--- a/approve-merge-pr/package.json
+++ b/approve-merge-pr/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "approve-merge-pr",
+  "type": "module",
+  "description": "Automated GitHub pr approval and merge tool using GitHub REST API.",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "STRG.",
+  "license": "MIT",
+  "dependencies": {
+    "@octokit/core": "6.1.3"
+  }
+}


### PR DESCRIPTION
added an improved version of the approve-merge and the merge pr apps used in our release helper repos.
merged the two apps into one (as everything can be approved) and updated all dependencies and node to 22.
see tests
https://github.com/jazzlyn/gh-actions-demo/pull/215
https://github.com/jazzlyn/gh-actions-demo/pull/212