### PR TITLE
ci: add build and push workflow for images INPRO-2560

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -2,21 +2,43 @@
 name: build and push docker image
 
 on:
-  workflow_dispatch:
-    inputs:
-      path:
-        description: "path to directory containing the Dockerfile file, f.e. postgres-db-init"
-        required: true
-        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - "*/**"
+      - "!.github/**"
+      - "!**/README.md"
 
 jobs:
-  docker-build-push:
-    uses: "strg-at/github-workflows/.github/workflows/docker-build-push-github.yaml@fe8aec8df10849c97cc87d1d2e1448d03121aceb" # v1.10.0
+  get-changed-files:
+    permissions:
+      contents: read
+    uses: strg-at/github-workflows/.github/workflows/get-changed-files.yaml@fe8aec8df10849c97cc87d1d2e1448d03121aceb
     with:
       runner: '["ubuntu-latest"]'
-      subpath: ${{ inputs.path }}
-      file: ${{ inputs.path }}/Dockerfile
-      context: ${{ inputs.path }}
+      files: |
+        **/*
+      matrix: true
+      dir_names: true
+
+  docker-build-push:
+    needs: [get-changed-files]
+    if: ${{ needs.get-changed-files.outputs.files != '[]' }}
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    strategy:
+      matrix:
+        paths: ${{ fromJSON(needs.get-changed-files.outputs.files) }}
+      fail-fast: false
+    uses: strg-at/github-workflows/.github/workflows/docker-build-push-github.yaml@fe8aec8df10849c97cc87d1d2e1448d03121aceb
+    with:
+      runner: '["ubuntu-latest"]'
+      subpath: ${{ matrix.paths }}
+      file: ${{ format('{0}/Dockerfile', matrix.paths) }}
+      context: ${{ matrix.paths }}
       tags: |
         ${{ github.sha }}
         type=raw, value=rolling

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -14,7 +14,7 @@ jobs:
   get-changed-files:
     permissions:
       contents: read
-    uses: strg-at/github-workflows/.github/workflows/get-changed-files.yaml@fe8aec8df10849c97cc87d1d2e1448d03121aceb
+    uses: strg-at/github-workflows/.github/workflows/get-changed-files.yaml@d4189e724a81f20b199661fb928863b83cfdf8d6 # v1.10.1
     with:
       runner: '["ubuntu-latest"]'
       files: |

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -6,8 +6,10 @@ on:
     types:
       - opened
       - synchronize
-    paths-ignore:
-      - .github/**
+    paths:
+      - "*/**"
+      - "!.github/**"
+      - "!**/README.md"
 
 concurrency:
   group: ${{ github.head_ref }}
@@ -21,13 +23,13 @@ jobs:
     with:
       runner: '["ubuntu-latest"]'
       files: |
-        **/Dockerfile
+        **/*
       matrix: true
       dir_names: true
 
   docker-build:
     needs: get-changed-files
-    if: ${{ needs.get-changed-files.outputs.files != '[]'}}
+    if: ${{ needs.get-changed-files.outputs.files != '[]' }}
     permissions:
       contents: read
       packages: read
@@ -38,5 +40,5 @@ jobs:
     uses: strg-at/github-workflows/.github/workflows/docker-build.yaml@fe8aec8df10849c97cc87d1d2e1448d03121aceb # v1.10.0
     with:
       runner: '["ubuntu-latest"]'
-      file: ${{ matrix.paths }}/Dockerfile
+      file: ${{ format('{0}/Dockerfile', matrix.paths) }}
       context: ${{ matrix.paths }}


### PR DESCRIPTION
build push ci now triggers when there is a change in one of the app folders.
build is just for the folders with changed files.
no manual step necessary anymore