### PR TITLE
feat(workstation): Install latest version of envsubst, INPRO-2352

### DIFF
--- a/gcloud-workstation-phpstorm/Dockerfile
+++ b/gcloud-workstation-phpstorm/Dockerfile
@@ -68,7 +68,7 @@ RUN apt update && apt install -y \
 RUN export latest=$(curl -s "https://go.dev/VERSION?m=text" | head -n 1) && wget https://go.dev/dl/$latest.linux-amd64.tar.gz && tar -C /usr/local -xzf $latest.linux-amd64.tar.gz && ln -s /usr/local/go/bin/go /usr/bin/go
 
 # install latest stable version from github, install it in /usr/local/bin due to PATH precedence
-RUN curl -o envsubst https://github.com/a8m/envsubst/releases/latest/download/envsubst-Linux-x86_64 \
+RUN curl -Lo envsubst https://github.com/a8m/envsubst/releases/latest/download/envsubst-Linux-x86_64 \
     && chmod +x envsubst \
     && mv envsubst /usr/local/bin/
 

--- a/gcloud-workstation-phpstorm/Dockerfile
+++ b/gcloud-workstation-phpstorm/Dockerfile
@@ -67,6 +67,11 @@ RUN apt update && apt install -y \
 # install latest go-lang stable
 RUN export latest=$(curl -s "https://go.dev/VERSION?m=text" | head -n 1) && wget https://go.dev/dl/$latest.linux-amd64.tar.gz && tar -C /usr/local -xzf $latest.linux-amd64.tar.gz && ln -s /usr/local/go/bin/go /usr/bin/go
 
+# install latest stable version from github, install it in /usr/local/bin due to PATH precedence
+RUN curl -o envsubst https://github.com/a8m/envsubst/releases/latest/download/envsubst-Linux-x86_64 \
+    && chmod +x envsubst \
+    && mv envsubst /usr/local/bin/
+
 # infra
 RUN apt install -y \
   flux \

--- a/gcloud-workstation-vscode/Dockerfile
+++ b/gcloud-workstation-vscode/Dockerfile
@@ -68,7 +68,7 @@ RUN apt update && apt install -y \
 RUN export latest=$(curl -s "https://go.dev/VERSION?m=text" | head -n 1) && wget https://go.dev/dl/$latest.linux-amd64.tar.gz && tar -C /usr/local -xzf $latest.linux-amd64.tar.gz && ln -s /usr/local/go/bin/go /usr/bin/go
 
 # install latest stable version from github, install it in /usr/local/bin due to PATH precedence
-RUN curl -o envsubst https://github.com/a8m/envsubst/releases/latest/download/envsubst-Linux-x86_64 \
+RUN curl -Lo envsubst https://github.com/a8m/envsubst/releases/latest/download/envsubst-Linux-x86_64 \
     && chmod +x envsubst \
     && mv envsubst /usr/local/bin/
 

--- a/gcloud-workstation-vscode/Dockerfile
+++ b/gcloud-workstation-vscode/Dockerfile
@@ -67,6 +67,11 @@ RUN apt update && apt install -y \
 # install latest go-lang stable
 RUN export latest=$(curl -s "https://go.dev/VERSION?m=text" | head -n 1) && wget https://go.dev/dl/$latest.linux-amd64.tar.gz && tar -C /usr/local -xzf $latest.linux-amd64.tar.gz && ln -s /usr/local/go/bin/go /usr/bin/go
 
+# install latest stable version from github, install it in /usr/local/bin due to PATH precedence
+RUN curl -o envsubst https://github.com/a8m/envsubst/releases/latest/download/envsubst-Linux-x86_64 \
+    && chmod +x envsubst \
+    && mv envsubst /usr/local/bin/
+
 # infra
 RUN apt install -y \
   flux \


### PR DESCRIPTION
Rather than uninstalling the current version shipped by default by ubuntu, install github's latest in /usr/local/bin:
```
user@w-mickaelsaavedra-lwrrk8y8 ~
 % echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/user/.local/share/gem/ruby//bin
```