### PR TITLE
fix(postgres-db-init): Use cascade for create extension sql statement…

### DIFF
--- a/postgres-db-init/entrypoint.sh
+++ b/postgres-db-init/entrypoint.sh
@@ -62,6 +62,6 @@ do
 
   if [[ "${POSTGRES_EXTENSION_ANON}" == "true" ]]; then
     printf "\e[1;32m%-6s\e[m\n" "create extension anon on ${init_db} with schema ${POSTGRES_USER} ..."
-    psql --dbname=${init_db} --command "CREATE EXTENSION IF NOT EXISTS \"anon\" WITH SCHEMA ${POSTGRES_USER};"
+    psql --dbname=${init_db} --command "CREATE EXTENSION IF NOT EXISTS \"anon\" WITH SCHEMA ${POSTGRES_USER} CASCADE;"
   fi
 done


### PR DESCRIPTION
…, GC-4168

See https://cloud.google.com/sql/docs/postgres/data-privacy-strategies#install-configure-extension

Current output otherwise:

```
stream logs failed container "state-service" in pod "state-service-8f44f75bf-bh4gg" is waiting to start: PodInitializing for dcc-integration/state-service-8f44f75bf-bh4gg (state-service)
db-init 10.40.224.6:5432 - accepting connections
db-init database user exists, skipping creation ...
db-init update database user password ...
db-init ALTER ROLE
db-init database exists, skipping creation ...
db-init update user privileges on database ...
db-init GRANT
db-init create schema integration_state_service for user integration_state_service
db-init CREATE SCHEMA
db-init NOTICE:  schema "integration_state_service" already exists, skipping
db-init create extension anon on integration_state_service with schema integration_state_service ...
db-init ERROR:  required extension "pgcrypto" is not installed
db-init HINT:  Use CREATE EXTENSION ... CASCADE to install required extensions too.
Stream closed EOF for dcc-integration/state-service-8f44f75bf-bh4gg (db-init)
```