### PR TITLE
fix(check-sitemap): Fix and improve implementation, NOENT-4661

### DIFF
--- a/check-sitemap/Dockerfile
+++ b/check-sitemap/Dockerfile
@@ -1,17 +1,17 @@
 FROM python:3.11-slim-bookworm
 
-RUN apt update && apt upgrade -y && apt install gettext cron netcat-traditional -y && \
+RUN apt update && apt upgrade -y && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /app/
 
-RUN pip3 install requests
+RUN pip3 install requests croniter
 
 WORKDIR /app
 
-RUN mkdir metrics && chmod +x /app/entrypoint.sh
+RUN mkdir metrics
 
 EXPOSE 8080
 
-ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["python3", "main.py"]

--- a/check-sitemap/entrypoint.sh
+++ b/check-sitemap/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-echo "Substituting environment variables in cronjob..."
-envsubst < /app/sitemap-cron > /etc/cron.d/sitemap-cron
-env | grep TARGET > /app/.env
-echo "Executing cron in foreground..."
-cron -f

--- a/check-sitemap/sitemap-cron
+++ b/check-sitemap/sitemap-cron
@@ -1,2 +1,0 @@
-TARGET="$TARGET"
-$CRON_SCHEDULE root /usr/local/bin/python3 /app/main.py >> /var/log/cron.log 2>&1


### PR DESCRIPTION
Requested chatgpt's help to be faster.

Changes:
- Added basic logging
- Got rid of system cron implementation to the favor of a python module handling cron expressions
- Webserver now runs all the time independently of the sitemap part

Tested locally:
```
> docker run -it --name check-sitemap -e TARGET="https://example.com/sitemap" -e CRON_SCHEDULE="* * * * *" --rm check-sitemap
2025-08-22 13:46:19,094 [INFO] Starting sitemap checker for https://example.com/sitemap
2025-08-22 13:46:19,094 [INFO] Using CRON_SCHEDULE='* * * * *'
2025-08-22 13:46:19,095 [INFO] HTTP server started at 0.0.0.0:8080
2025-08-22 13:47:00,100 [INFO] ⏰ Running job scheduled at 2025-08-22 13:47:00+00:00
2025-08-22 13:47:00,249 [INFO] Downloaded sitemap (45615 bytes) -> /tmp/tmphlknb2ha
2025-08-22 13:47:00,254 [INFO] Sitemap analysis: 257 items, newest=36720s, oldest=37006s
2025-08-22 13:47:00,255 [INFO] ✅ Metrics file updated
2025-08-22 13:47:00,256 [INFO] Next run scheduled at 2025-08-22 13:48:00+00:00
2025-08-22 13:48:00,262 [INFO] ⏰ Running job scheduled at 2025-08-22 13:48:00+00:00
2025-08-22 13:48:00,373 [INFO] Downloaded sitemap (45615 bytes) -> /tmp/tmp5f068hl7
2025-08-22 13:48:00,376 [INFO] Sitemap analysis: 257 items, newest=36780s, oldest=37066s
2025-08-22 13:48:00,377 [INFO] ✅ Metrics file updated
2025-08-22 13:48:00,377 [INFO] Next run scheduled at 2025-08-22 13:49:00+00:00
2025-08-22 13:49:00,384 [INFO] ⏰ Running job scheduled at 2025-08-22 13:49:00+00:00
```
