### PR TITLE
feature/EAWU-1680-add-if-block-for-pgvector-extension

### DIFF
--- a/postgres-db-init/README.md
+++ b/postgres-db-init/README.md
@@ -27,6 +27,8 @@ database (schema) initialization helper
 | **POSTGRES_PASS**                | postgres password                              |
 | **POSTGRES_DB**                  | postgres database                              |
 | **POSTGRES_EXTENSION_UUID_OSSP** | create extension uuid-ossp (optional, boolean) |
+| **POSTGRES_EXTENSION_ANON**      | create extension anon (optional, boolean)      |
+| **POSTGRES_EXTENSION_VECTOR**    | create extension vector (optional, boolean)    |
 
 | (\*) required
 

--- a/postgres-db-init/entrypoint.sh
+++ b/postgres-db-init/entrypoint.sh
@@ -64,4 +64,9 @@ do
     printf "\e[1;32m%-6s\e[m\n" "create extension anon on ${init_db} with schema ${POSTGRES_USER} ..."
     psql --dbname=${init_db} --command "CREATE EXTENSION IF NOT EXISTS \"anon\" WITH SCHEMA ${POSTGRES_USER} CASCADE;"
   fi
+
+  if [[ "${POSTGRES_EXTENSION_VECTOR}" == "true" ]]; then
+    printf "\e[1;32m%-6s\e[m\n" "create extension vector on ${init_db} with schema ${POSTGRES_USER} ..."
+    psql --dbname=${init_db} --command "CREATE EXTENSION IF NOT EXISTS \"vector\" WITH SCHEMA ${POSTGRES_USER} CASCADE;"
+  fi
 done


### PR DESCRIPTION
Similarly to other postgres extensions, the vector extension can be created on a given database if passing the relevant environment variable.