### PR TITLE
bugfix/INPRO-3187-use-latest-helm-version-in-cloud-workstation

### DIFF
--- a/gcloud-workstation-phpstorm/Dockerfile
+++ b/gcloud-workstation-phpstorm/Dockerfile
@@ -47,11 +47,6 @@ RUN curl -sSL https://raw.githubusercontent.com/upciti/wakemeops/main/assets/ins
 # install mise
 RUN curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
 
-# install helm 3
-RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
-  && chmod 700 get_helm.sh \
-  && ./get_helm.sh
-
 RUN apt update && add-apt-repository ppa:git-core/ppa -y && DEBIAN_FRONTEND=noninteractive apt install -y \
   ack-grep \
   ca-certificates \
@@ -69,6 +64,7 @@ RUN apt update && add-apt-repository ppa:git-core/ppa -y && DEBIAN_FRONTEND=noni
   go-task=3.41.0-1~ops2deb \
   google-cloud-cli \
   gpg \
+  helm \
   htop \
   k9s \
   kind \

--- a/gcloud-workstation-vscode/Dockerfile
+++ b/gcloud-workstation-vscode/Dockerfile
@@ -47,11 +47,6 @@ RUN curl -sSL https://raw.githubusercontent.com/upciti/wakemeops/main/assets/ins
 # install mise
 RUN curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
 
-# install helm 3
-RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
-  && chmod 700 get_helm.sh \
-  && ./get_helm.sh
-
 RUN apt update && add-apt-repository ppa:git-core/ppa -y && DEBIAN_FRONTEND=noninteractive apt install -y \
   ack-grep \
   ca-certificates \
@@ -69,6 +64,7 @@ RUN apt update && add-apt-repository ppa:git-core/ppa -y && DEBIAN_FRONTEND=noni
   go-task=3.41.0-1~ops2deb \
   google-cloud-cli \
   gpg \
+  helm \
   htop \
   k9s \
   kind \


### PR DESCRIPTION
Tested with a local build:
```
user@de5100531c43 ~ % helm version
version.BuildInfo{Version:"v4.2.3", GitCommit:"43e8b7feece8beb0fcba47059ec9b522fd929a64", GitTreeState:"clean", GoVersion:"go1.26.5", KubeClientVersion:"v1.36"}
```